### PR TITLE
Security dump protections by handling sensitive data as functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
+build-*
 extern

--- a/WebServerAdapterInterface/Model/SecurityConfiguration.h
+++ b/WebServerAdapterInterface/Model/SecurityConfiguration.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 namespace systelab { namespace web_server {
 
 	class SecurityConfiguration
@@ -10,9 +12,9 @@ namespace systelab { namespace web_server {
 		inline virtual ~SecurityConfiguration();
 
 		inline bool isHTTPSEnabled() const;
-		inline std::string getServerCertificate() const;
-		inline std::string getServerPrivateKey() const;
-		inline std::string getServerDHParam() const;
+		inline std::function<std::string()> getServerCertificate() const;
+		inline std::function<std::string()> getServerPrivateKey() const;
+		inline std::function<std::string()> getServerDHParam() const;
 
 		inline bool isMutualSSLEnabled() const;
 		inline std::string getClientCertificate() const;
@@ -23,9 +25,9 @@ namespace systelab { namespace web_server {
 		inline bool isTLSv13Enabled() const;
 
 		inline void setHTTPSEnabled(bool);
-		inline void setServerCertificate(const std::string&);
-		inline void setServerPrivateKey(const std::string&);
-		inline void setServerDHParam(const std::string&);
+		inline void setServerCertificate(const std::function<std::string()>&);
+		inline void setServerPrivateKey(const std::function<std::string()>&);
+		inline void setServerDHParam(const std::function<std::string()>&);
 
 		inline void setMutualSSLEnabled(bool);
 		inline void setClientCertificate(const std::string&);
@@ -39,9 +41,9 @@ namespace systelab { namespace web_server {
 
 	private:
 		bool m_httpsEnabled;
-		std::string m_serverCertificate;
-		std::string m_serverPrivateKey;
-		std::string m_serverDHParam;
+		std::function<std::string()> m_serverCertificate;
+		std::function<std::string()> m_serverPrivateKey;
+		std::function<std::string()> m_serverDHParam;
 
 		bool m_mutualSSLEnabled;
 		std::string m_clientCertificate;

--- a/WebServerAdapterInterface/Model/SecurityConfiguration.inl
+++ b/WebServerAdapterInterface/Model/SecurityConfiguration.inl
@@ -3,9 +3,9 @@ namespace systelab { namespace web_server {
 
 	SecurityConfiguration::SecurityConfiguration()
 		:m_httpsEnabled(false)
-		,m_serverCertificate("")
-		,m_serverPrivateKey("")
-		,m_serverDHParam("")
+		,m_serverCertificate()
+		,m_serverPrivateKey()
+		,m_serverDHParam()
 		,m_mutualSSLEnabled(false)
 		,m_clientCertificate("")
 		,m_tlsv10Enabled(false)
@@ -36,17 +36,17 @@ namespace systelab { namespace web_server {
 		return m_httpsEnabled;
 	}
 
-	std::string SecurityConfiguration::getServerCertificate() const
+	std::function<std::string()> SecurityConfiguration::getServerCertificate() const
 	{
 		return m_serverCertificate;
 	}
 
-	std::string SecurityConfiguration::getServerPrivateKey() const
+	std::function<std::string()> SecurityConfiguration::getServerPrivateKey() const
 	{
 		return m_serverPrivateKey;
 	}
 
-	std::string SecurityConfiguration::getServerDHParam() const
+	std::function<std::string()> SecurityConfiguration::getServerDHParam() const
 	{
 		return m_serverDHParam;
 	}
@@ -86,17 +86,17 @@ namespace systelab { namespace web_server {
 		m_httpsEnabled = httpsEnabled;
 	}
 
-	void SecurityConfiguration::setServerCertificate(const std::string& serverCertificate)
+	void SecurityConfiguration::setServerCertificate(const std::function<std::string()>& serverCertificate)
 	{
 		m_serverCertificate = serverCertificate;
 	}
 
-	void SecurityConfiguration::setServerPrivateKey(const std::string& serverPrivateKey)
+	void SecurityConfiguration::setServerPrivateKey(const std::function<std::string()>& serverPrivateKey)
 	{
 		m_serverPrivateKey = serverPrivateKey;
 	}
 
-	void SecurityConfiguration::setServerDHParam(const std::string& serverDHParam)
+	void SecurityConfiguration::setServerDHParam(const std::function<std::string()>& serverDHParam)
 	{
 		m_serverDHParam = serverDHParam;
 	}

--- a/WebServerAdapterTestUtilities/Comparators/SecurityConfigurationComparator.cpp
+++ b/WebServerAdapterTestUtilities/Comparators/SecurityConfigurationComparator.cpp
@@ -14,9 +14,9 @@ namespace systelab { namespace test_utility {
 														   const systelab::web_server::SecurityConfiguration& actual) const
 	{
 		COMPARATOR_ASSERT_EQUAL(expected, actual, isHTTPSEnabled());
-		COMPARATOR_ASSERT_EQUAL(expected, actual, getServerCertificate());
-		COMPARATOR_ASSERT_EQUAL(expected, actual, getServerPrivateKey());
-		COMPARATOR_ASSERT_EQUAL(expected, actual, getServerDHParam());
+		COMPARATOR_ASSERT_EQUAL(expected, actual, getServerCertificate()());
+		COMPARATOR_ASSERT_EQUAL(expected, actual, getServerPrivateKey()());
+		COMPARATOR_ASSERT_EQUAL(expected, actual, getServerDHParam()());
 
 		COMPARATOR_ASSERT_EQUAL(expected, actual, isMutualSSLEnabled());
 		COMPARATOR_ASSERT_EQUAL(expected, actual, getClientCertificate());


### PR DESCRIPTION
This is about handling:

- Server certificate
- Private key
- DH params

As functions (instead od strings) to avoid memorry dump attacks.
